### PR TITLE
Add per-state job-level metrics

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -11,4 +11,6 @@ var (
 	nodeLabels = []string{"node"}
 
 	partitionLabels = []string{"partition"}
+
+	jobLabels = []string{"job_id", "job_name", "node"}
 )

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -159,6 +159,7 @@ var (
 var (
 	job0 = &types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
 		JobId:     ptr.To[int32](0),
+		Name:      ptr.To("test_job_0"),
 		JobState:  ptr.To([]api.V0041JobInfoJobState{api.V0041JobInfoJobStateRUNNING}),
 		Partition: partition1.Name,
 		JobResources: &api.V0041JobRes{
@@ -169,6 +170,7 @@ var (
 				SelectType *[]api.V0041JobResNodesSelectType "json:\"select_type,omitempty\""
 				Whole      *bool                             "json:\"whole,omitempty\""
 			}{
+				List: ptr.To("node1"),
 				Allocation: &api.V0041JobResNodes{
 					{
 						Cpus: &struct {
@@ -193,6 +195,7 @@ var (
 	}}
 	job1 = &types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
 		JobId:     ptr.To[int32](1),
+		Name:      ptr.To("test_job_1"),
 		JobState:  ptr.To([]api.V0041JobInfoJobState{api.V0041JobInfoJobStatePENDING}),
 		Partition: ptr.To(strings.Join([]string{partition1Name, partition2Name}, ",")),
 		Hold:      ptr.To(true),
@@ -205,6 +208,7 @@ var (
 	}}
 	job2 = &types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
 		JobId:     ptr.To[int32](2),
+		Name:      ptr.To("test_job_2"),
 		JobState:  ptr.To([]api.V0041JobInfoJobState{api.V0041JobInfoJobStateRUNNING}),
 		Partition: partition2.Name,
 		JobResources: &api.V0041JobRes{
@@ -215,6 +219,7 @@ var (
 				SelectType *[]api.V0041JobResNodesSelectType "json:\"select_type,omitempty\""
 				Whole      *bool                             "json:\"whole,omitempty\""
 			}{
+				List: ptr.To("node2,node3"),
 				Allocation: &api.V0041JobResNodes{
 					{
 						Cpus: &struct {
@@ -252,6 +257,7 @@ var (
 	}}
 	job3 = &types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
 		JobId:     ptr.To[int32](3),
+		Name:      ptr.To("test_job_3"),
 		JobState:  ptr.To([]api.V0041JobInfoJobState{api.V0041JobInfoJobStatePENDING}),
 		Partition: ptr.To(partition2Name),
 		NodeCount: &api.V0041Uint32NoValStruct{

--- a/internal/collector/util.go
+++ b/internal/collector/util.go
@@ -4,6 +4,7 @@
 package collector
 
 import (
+	"fmt"
 	"math"
 
 	"k8s.io/utils/ptr"
@@ -37,4 +38,72 @@ func ParseUint32NoVal(noVal *api.V0041Uint32NoValStruct) uint32 {
 	}
 	number := uint32(ptr.Deref(noVal.Number, 0))
 	return number
+}
+
+// parseNodeList parses Slurm node list formats
+// Examples:
+//   - "node1" -> ["node1"]
+//   - "node1,node2" -> ["node1", "node2"]
+//   - "node[1-3]" -> ["node1", "node2", "node3"]
+//   - "node[1,3,5]" -> ["node1", "node3", "node5"]
+//   - "node-[913,928,955]" -> ["node-913", "node-928", "node-955"]
+func parseNodeList(nodeList string) []string {
+	var nodes []string
+
+	// Check if it contains bracket notation
+	bracketStart := strings.Index(nodeList, "[")
+	bracketEnd := strings.Index(nodeList, "]")
+
+	if bracketStart != -1 && bracketEnd != -1 && bracketEnd > bracketStart {
+		// Extract prefix and suffix
+		prefix := nodeList[:bracketStart]
+		suffix := ""
+		if bracketEnd+1 < len(nodeList) {
+			suffix = nodeList[bracketEnd+1:]
+		}
+
+		// Extract the content inside brackets
+		bracketContent := nodeList[bracketStart+1 : bracketEnd]
+
+		// Parse the bracket content
+		parts := strings.Split(bracketContent, ",")
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if strings.Contains(part, "-") {
+				// Handle range notation like "1-3"
+				rangeParts := strings.Split(part, "-")
+				if len(rangeParts) == 2 {
+					start := 0
+					end := 0
+					_, err1 := fmt.Sscanf(rangeParts[0], "%d", &start)
+					_, err2 := fmt.Sscanf(rangeParts[1], "%d", &end)
+					if err1 == nil && err2 == nil {
+						for i := start; i <= end; i++ {
+							nodes = append(nodes, fmt.Sprintf("%s%d%s", prefix, i, suffix))
+						}
+					}
+				}
+			} else {
+				// Single number
+				nodes = append(nodes, fmt.Sprintf("%s%s%s", prefix, part, suffix))
+			}
+		}
+	} else if strings.Contains(nodeList, ",") {
+		// Simple comma-separated list
+		parts := strings.Split(nodeList, ",")
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				nodes = append(nodes, part)
+			}
+		}
+	} else {
+		// Single node
+		nodeList = strings.TrimSpace(nodeList)
+		if nodeList != "" {
+			nodes = append(nodes, nodeList)
+		}
+	}
+
+	return nodes
 }

--- a/internal/collector/util_test.go
+++ b/internal/collector/util_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (C) SchedMD LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+import "testing"
+
+func Test_parseNodeList(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeList string
+		want     []string
+	}{
+		{
+			name:     "single node",
+			nodeList: "node1",
+			want:     []string{"node1"},
+		},
+		{
+			name:     "comma separated nodes",
+			nodeList: "node1,node2,node3",
+			want:     []string{"node1", "node2", "node3"},
+		},
+		{
+			name:     "bracket notation with range",
+			nodeList: "node[1-3]",
+			want:     []string{"node1", "node2", "node3"},
+		},
+		{
+			name:     "bracket notation with list",
+			nodeList: "node[1,3,5]",
+			want:     []string{"node1", "node3", "node5"},
+		},
+		{
+			name:     "complex slurm format",
+			nodeList: "node-[913,928,955,954,517,557,600,555,586,524,601,575,572,626,662,696,671,717,702,720,793,768,791,781,814,751,790,846,873,816,898,895]",
+			want: []string{
+				"node-913", "node-928", "node-955", "node-954",
+				"node-517", "node-557", "node-600", "node-555",
+				"node-586", "node-524", "node-601", "node-575",
+				"node-572", "node-626", "node-662", "node-696",
+				"node-671", "node-717", "node-702", "node-720",
+				"node-793", "node-768", "node-791", "node-781",
+				"node-814", "node-751", "node-790", "node-846",
+				"node-873", "node-816", "node-898", "node-895",
+			},
+		},
+		{
+			name:     "bracket notation with mixed range and list",
+			nodeList: "compute[1-3,5,7-9]",
+			want:     []string{"compute1", "compute2", "compute3", "compute5", "compute7", "compute8", "compute9"},
+		},
+		{
+			name:     "empty string",
+			nodeList: "",
+			want:     []string{},
+		},
+		{
+			name:     "single node with bracket",
+			nodeList: "node[42]",
+			want:     []string{"node42"},
+		},
+		{
+			name:     "node with suffix after bracket",
+			nodeList: "rack[1-2]node",
+			want:     []string{"rack1node", "rack2node"},
+		},
+		{
+			name:     "comma separated with spaces",
+			nodeList: "node1, node2, node3",
+			want:     []string{"node1", "node2", "node3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNodeList(tt.nodeList)
+			if len(got) != len(tt.want) {
+				t.Errorf("parseNodeList() returned %d nodes, want %d nodes", len(got), len(tt.want))
+				t.Errorf("got: %v", got)
+				t.Errorf("want: %v", tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseNodeList()[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What?

Add metrics that are emitted for every job, showing the exact state it is in.

# Why?

This fills a hole in the existing metrics, as you couldn't answer questions like:

- What jobs are running on this node, and what are their states over time?
- What are the states of job with ID `x` over time?
- What are the states of the job with name `y` over time?

And then you can combine these questions and have something like a timeline of states for a specific job on a specific node:

![image](https://github.com/user-attachments/assets/197fc089-f1fd-4e63-b3fe-051d3dfa5f10)

So this change helps job-level and node-level observability quite nicely.

# Performance?

To avoid cardinality problems, I chose to only emit each metric if the job is actually in that state. This massively reduces the number of metrics emitted.

This means however that, depending on what you're trying to accomplish, you may have to add an `or vector(0)` to your queries like: `max(avg by (job_id) (slurm_job_state_running{cluster="$cluster", job_id="$job_id"}) or vector(0))`, but I think that's a fine price to pay.

# Tested?

We have this running in production for many weeks and it works fine! It didn't result in an explosion of metrics or anything.

There is also a unit test.

# Caveats?

Please note that I don't really know go at all. There may be some go issues here. Do let me know if you want any changes.