### PR TITLE
feat: add custom labels support to ServiceMonitor

### DIFF
--- a/helm/slurm-exporter/templates/metrics/service-monitor.yaml
+++ b/helm/slurm-exporter/templates/metrics/service-monitor.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ include "slurm-exporter.namespace" . }}
   labels:
     {{- include "slurm-exporter.labels" . | nindent 4 }}
+    {{- with .Values.exporter.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
   - interval: 5s

--- a/helm/slurm-exporter/values.yaml
+++ b/helm/slurm-exporter/values.yaml
@@ -88,6 +88,13 @@ exporter:
   # Service monitor configurations.
   serviceMonitor:
     enabled: true
+    #
+    # -- (object)
+    # Additional labels to add to the ServiceMonitor resource.
+    # These labels can be used by Prometheus to discover the ServiceMonitor.
+    # Ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/getting-started/design.md#servicemonitor
+    # Helm Usage: `helm upgrade -i ... --set exporter.serviceMonitor.labels.release=kube-prometheus-stack`
+    labels: {}
     endpoints:
       - port: metrics
         path: /metrics


### PR DESCRIPTION

## Summary

This PR adds support for custom labels on the ServiceMonitor resource. Specifically, it introduces `exporter.serviceMonitor.labels`, allowing users to append key–value pairs to `metadata.labels`. Because Prometheus (via the Prometheus Operator) discovers ServiceMonitors via label and namespace selectors, these labels enable reliable discovery (e.g., with kube-prometheus-stack).

## Changes

- Added `exporter.serviceMonitor.labels` (default `{}`) configuration option in `values.yaml`
- Updated `service-monitor.yaml` template to merge custom labels with existing labels
- Added comprehensive documentation and reference links

## Motivation

When using Prometheus Operator, Prometheus instances typically use label selectors (e.g., `serviceMonitorSelector`) to discover which ServiceMonitors to scrape. Without the ability to add custom labels to the ServiceMonitor resource, users cannot configure their Prometheus instances to discover this exporter.

## Usage Example

Users can now configure custom labels in their `values.yaml`:

```yaml
exporter:
  serviceMonitor:
    enabled: true
    labels:
      prometheus: kube-prometheus
      release: kube-prometheus-stack
```

This allows Prometheus with matching selectors to discover and scrape the slurm-exporter metrics.

## Testing

- [ ] Verified Helm template rendering with custom labels

    ```bash
    $ cd helm/slurm-exporter
    $ helm template my . \
         --set exporter.secretName=my-secret \
         --api-versions='monitoring.coreos.com/v1' \
         --set exporter.serviceMonitor.labels.prometheus=kube-prometheus \
         --set exporter.serviceMonitor.labels.release=kube-prometheus-stack \
         --show-only templates/metrics/service-monitor.yaml
    ```
- [ ] Confirmed labels are properly merged with existing labels
    ```yaml
    # Source: slurm-exporter/templates/metrics/service-monitor.yaml
    apiVersion: monitoring.coreos.com/v1
    kind: ServiceMonitor
    metadata:
      name: slurm-exporter
      namespace: default
      labels:
        helm.sh/chart: slurm-exporter-0.4.0
        app.kubernetes.io/version: "25.05"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: slurm-exporter
        app.kubernetes.io/name: slurm-exporter
        app.kubernetes.io/instance: slurm-exporter
        prometheus: kube-prometheus
        release: kube-prometheus-stack
    ...
    ```
- [ ] Tested with Prometheus Operator in Kubernetes cluster

## References

- [Prometheus Operator ServiceMonitor Documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/getting-started/design.md#servicemonitor)
